### PR TITLE
Some improvements to avoid overflow in code

### DIFF
--- a/algorithms/binary_search/cpp/binary_search.cpp
+++ b/algorithms/binary_search/cpp/binary_search.cpp
@@ -7,7 +7,7 @@ bool binarySearchIterative(int list[], int first, int end, int item){
 	int middle;
 
 	while(first <= end){
-		middle = (first + end)/2;
+		middle = first + ((end-first)/2) //to avoid overflow of int.
 		if(list[middle] == item) {
 			return true;
 		}
@@ -22,7 +22,7 @@ bool binarySearchIterative(int list[], int first, int end, int item){
 
 bool binarySearchRecursive(int list[], int first, int end, int item){
 
-	int middle = (first + end)/2;
+	int middle = first + ((end - first)/2); // to avoid overflow of int type
 
 	if(list[middle] == item){
 		return true;


### PR DESCRIPTION
As the int size in int is limited, if we do mid = (first+end)/2 , then if anyone of them is at the limit value of int, the mid value will overflow and junk value will be put.
That's why first + (end-first)/2 